### PR TITLE
Fix tests on Windows CI

### DIFF
--- a/test/test.rs
+++ b/test/test.rs
@@ -16,7 +16,7 @@ mod tests {
     use tokio::net::TcpListener;
 
     async fn setup() -> (TcpListener, Connection) {
-        let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let conn = Connection::dial(addr).await.unwrap();
         (listener, conn)


### PR DESCRIPTION
Binding to `0.0.0.0` does not work as expected on Windows... This PR aims to find an alternative